### PR TITLE
Hex prefix

### DIFF
--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -52,6 +52,11 @@ exports.datatypeHexadecimal = {
   description: "Get random hexadecimal",
   args: [
     {
+      displayName: "Prefix",
+      type: "string",
+      defaultValue: "0x"
+    },
+    {
       displayName: "Case",
       type: "enum",
       options: [
@@ -66,9 +71,9 @@ exports.datatypeHexadecimal = {
       defaultValue: 4
     }
   ],
-  run: async (context, hexCase, length) => {
+  run: async (context, prefix, hexCase, length) => {
     length = length < 1 || length > 64 ? 4 : length;
-    return faker.datatype.hexadecimal({ case: hexCase, length: length });
+    return faker.datatype.hexadecimal({ prefix: prefix, case: hexCase, length: length });
   }
 };
 

--- a/lib/datatype.js
+++ b/lib/datatype.js
@@ -61,18 +61,19 @@ exports.datatypeHexadecimal = {
       type: "enum",
       options: [
         { displayName: "Lower", value: "lower" },
+        { displayName: "Mixed", value: "mixed" },
         { displayName: "Upper", value: "upper" }
       ]
     },
     {
-      displayName: "Length min 1, max 64, defaults to 4 ",
-      description: "Length of the value minimum 1 maximum 64, defaults to 4",
+      displayName: "Length min 1, defaults to 4 ",
+      description: "Length of the value minimum 1, defaults to 4",
       type: "number",
       defaultValue: 4
     }
   ],
   run: async (context, prefix, hexCase, length) => {
-    length = length < 1 || length > 64 ? 4 : length;
+    length = length < 1 ? 4 : length;
     return faker.datatype.hexadecimal({ prefix: prefix, case: hexCase, length: length });
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "insomnia-plugin-fake",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "insomnia-plugin-fake",
-      "version": "2.0.0",
+      "version": "2.0.3",
+      "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "dayjs": "^1.11.7"


### PR DESCRIPTION
I need to be able to disable the hex prefix in order to generate random Span/Trace Ids. While I'm at it I nitpicked mixed case support and no max length (I think faker supports Number.MAX_SAFE_INTEGER).

I guessed that this was all I needed to do. Let me know if there's more to it. There's no npm script for build or test so IDK if this works. Although I forgot to update the version. I suppose this would be 2.1.0 if you consider this a feature.

I thought about updating the faker version using https://github.com/faker-js/faker/blob/v8.0.2/src/modules/string/index.ts#L461 but decided that it wasn't my problem (could be a big change).